### PR TITLE
Remove deprecation notice on .toPromise()

### DIFF
--- a/operators/utility/topromise.md
+++ b/operators/utility/topromise.md
@@ -6,7 +6,7 @@
 
 ---
 
-:warning: `toPromise` has been deprecated! (RxJS 5.5+)
+:warning: `toPromise` is not a pipable operator, as it does not return an observable.
 
 ---
 


### PR DESCRIPTION
I found the deprecation notice on `toPromise` to be very confusing, since no alternative is provided. I did some looking and couldn't find any evidence that it's been deprecated.

The short-lived pipable `toPromise` _was_ deprecated soon after it was made, but the one on the observable prototype lives on (which is what was documented on this page anyway).

[toPromise still exists in the RxJS codebase without any deprecation notice](https://github.com/ReactiveX/rxjs/blob/master/src/internal/Observable.ts#L346), and it is not mentioned in the [migration guide](https://github.com/ReactiveX/rxjs/blob/master/docs_app/content/guide/v6/migration.md#deprecations).

(The code samples should probably be updated too, but I want to narrow the scope of this PR.)